### PR TITLE
Updated forgotten keyword

### DIFF
--- a/geoip.inc
+++ b/geoip.inc
@@ -140,7 +140,7 @@ stock GetPlayerIPBlock(playerid, &block) {
 hook OnScriptInit() {
     new key[] = IPHUB_KEY;
     if(strlen(key) == 0) {
-        fatal("IPHUB_KEY must be set for geoip library");
+        Logger_Fatal("IPHUB_KEY must be set for geoip library");
     }
 
     Client = RequestsClient("http://v2.api.iphub.info/ip/", RequestHeaders("X-Key", key));


### PR DESCRIPTION
Updated the `fatal` keyword to use the updated function names. This was mistakenly forgotten